### PR TITLE
Remove hard-coded Ruby version

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,3 @@
-#!/usr/bin/env ruby2.2
+#!/usr/bin/env ruby
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 load Gem.bin_path('bundler', 'bundle')

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby2.2
+#!/usr/bin/env ruby
 begin
   load File.expand_path('../spring', __FILE__)
 rescue LoadError => e

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby2.2
+#!/usr/bin/env ruby
 begin
   load File.expand_path('../spring', __FILE__)
 rescue LoadError => e

--- a/bin/setup
+++ b/bin/setup
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby2.2
+#!/usr/bin/env ruby
 require 'pathname'
 
 # path to your application root.


### PR DESCRIPTION
I'm not sure why this would have been added originally, but it prevents the `bin/setup` script from running.